### PR TITLE
Fix: squid:S1118, Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/com/ronakmanglani/watchlist/database/MovieDatabase.java
+++ b/app/src/main/java/com/ronakmanglani/watchlist/database/MovieDatabase.java
@@ -10,4 +10,7 @@ public class MovieDatabase {
 
     @Table(MovieColumns.class) public static final String WATCHED = "watched";
     @Table(MovieColumns.class) public static final String TO_SEE = "to_see";
+
+    private MovieDatabase() {
+    }
 }

--- a/app/src/main/java/com/ronakmanglani/watchlist/database/MovieProvider.java
+++ b/app/src/main/java/com/ronakmanglani/watchlist/database/MovieProvider.java
@@ -11,6 +11,9 @@ public class MovieProvider {
 
     public static final String AUTHORITY = "com.ronakmanglani.watchlist.database.MovieProvider";
 
+    private MovieProvider() {
+    }
+
     // Table for movies seen
     @TableEndpoint(table = MovieDatabase.WATCHED) public static class Watched {
         @ContentUri(
@@ -18,6 +21,9 @@ public class MovieProvider {
                 type = "vnd.android.cursor.dir/list",
                 defaultSort = MovieColumns.TITLE + " ASC")
         public static final Uri CONTENT_URI = Uri.parse("content://" + AUTHORITY + "/watched");
+
+        private Watched() {
+        }
     }
 
     // Table for movies to see
@@ -27,5 +33,8 @@ public class MovieProvider {
                 type = "vnd.android.cursor.dir/list",
                 defaultSort = MovieColumns.TITLE + " ASC")
         public static final Uri CONTENT_URI = Uri.parse("content://" + AUTHORITY + "/to_see");
+
+        private ToSee() {
+        }
     }
 }

--- a/app/src/main/java/com/ronakmanglani/watchlist/util/ApiHelper.java
+++ b/app/src/main/java/com/ronakmanglani/watchlist/util/ApiHelper.java
@@ -7,6 +7,9 @@ import com.ronakmanglani.watchlist.R;
 
 public class ApiHelper {
 
+    private ApiHelper() {
+    }
+
     // API key for TMDB
     public static String getTMDBKey(Context context) {
         return context.getString(R.string.tmdb_api_key);

--- a/app/src/main/java/com/ronakmanglani/watchlist/util/FileUtils.java
+++ b/app/src/main/java/com/ronakmanglani/watchlist/util/FileUtils.java
@@ -14,6 +14,9 @@ import java.nio.channels.FileChannel;
 
 public class FileUtils {
 
+    private FileUtils() {
+    }
+
     public static void copyFile(File source, File destination) throws IOException {
         FileInputStream fromFile = new FileInputStream(source);
         FileOutputStream toFile = new FileOutputStream(destination);

--- a/app/src/main/java/com/ronakmanglani/watchlist/util/FontCache.java
+++ b/app/src/main/java/com/ronakmanglani/watchlist/util/FontCache.java
@@ -13,6 +13,9 @@ public class FontCache {
 
     private static Hashtable<String, Typeface> fontCache = new Hashtable<String, Typeface>();
 
+    private FontCache() {
+    }
+
     public static Typeface getTypeface(String name, Context context) {
         Typeface tf = fontCache.get(name);
         if(tf == null) {

--- a/app/src/main/java/com/ronakmanglani/watchlist/util/TextUtils.java
+++ b/app/src/main/java/com/ronakmanglani/watchlist/util/TextUtils.java
@@ -2,6 +2,9 @@ package com.ronakmanglani.watchlist.util;
 
 public class TextUtils {
 
+    private TextUtils() {
+    }
+
     public static boolean isNullOrEmpty(String str) {
         return (str == null || str.equals("null") || str.equals(""));
     }

--- a/app/src/main/java/com/ronakmanglani/watchlist/util/YoutubeHelper.java
+++ b/app/src/main/java/com/ronakmanglani/watchlist/util/YoutubeHelper.java
@@ -2,6 +2,9 @@ package com.ronakmanglani.watchlist.util;
 
 public class YoutubeHelper {
 
+    private YoutubeHelper() {
+    }
+
     // Get video URL
     public static String getVideoURL(String youtubeID) {
         return "https://www.youtube.com/watch?v=" + youtubeID;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118

 Please let me know if you have any questions.
Ayman Elkfrawy.
